### PR TITLE
Implement persistent ticking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "speakstream"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speakstream"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A streaming text-to-speech library using OpenAI's API."
 license = "MIT"


### PR DESCRIPTION
## Summary
- add new `ConvertingFinished` and `Reset` states
- reset ticking state on `stop_speech`
- tick when any conversions are pending and voice is idle

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68524406e1bc83328f48d613b968a685