### PR TITLE
♻️ (lib): stop re-exporting DefaultDeviceSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A streaming text-to-speech library built on OpenAI's API. Feed tokens as they ar
 - 🗣️ **Change voices** easily using OpenAI's voice models.
 - ⏩ **Adjust playback speed** on the fly.
 - 🔇 **Mute/unmute** or stop speech instantly.
-- 🔊 **Automatic output device switching** with `DefaultDeviceSink`.
+- 🔊 **Automatic output device switching** via the `default-device-sink` crate.
 - ✅ **Tick and error sounds** for progress and failures.
 
 ## Setup

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,2 @@
 pub mod audio_ducking;
 pub mod ss;
-
-pub mod default_device_sink {
-    pub use ::default_device_sink::*;
-}

--- a/src/ss.rs
+++ b/src/ss.rs
@@ -7,7 +7,7 @@ use async_std::future;
 use colored::Colorize;
 
 use crate::audio_ducking::AudioDucker;
-use crate::default_device_sink::DefaultDeviceSink;
+use default_device_sink::DefaultDeviceSink;
 use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path::Path;


### PR DESCRIPTION
## Summary
- remove re-export of `DefaultDeviceSink`
- import `DefaultDeviceSink` directly from its crate
- update documentation to reference the external crate

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685504219828833294a1d455ad6fb14a