### PR TITLE
Ensure ducking undone on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2020,7 @@ dependencies = [
  "futures",
  "once_cell",
  "rodio",
+ "signal-hook",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1"
 futures = "0.3"
 tokio = { version = "1.29.0", features = ["macros", "rt-multi-thread"] }
 default-device-sink = "0.1.0"
+signal-hook = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.54.0", features = [


### PR DESCRIPTION
## Summary
- use `signal-hook` to capture termination signals
- register active audio duckers
- restore volumes on drop and when handling signals

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68551d013cb483329e0bbdd452e635ea