### PR TITLE
Implement runtime toggles for tick and ducking

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use async_openai::types::Voice;
 
 #[tokio::main]
 async fn main() {
-    let mut speak = SpeakStream::new(Voice::Alloy, 1.0, true);
+    let mut speak = SpeakStream::new(Voice::Alloy, 1.0, true, false);
     speak.add_token("Hello, world!");
     speak.complete_sentence();
 }
@@ -55,7 +55,7 @@ async fn main() {
 Audio ducking can be enabled when creating a new stream or toggled at runtime:
 
 ```rust
-let mut speak = SpeakStream::new_with_ducking(Voice::Alloy, 1.0, true, true);
+let mut speak = SpeakStream::new(Voice::Alloy, 1.0, true, true);
 assert!(speak.is_audio_ducking_enabled());
 speak.set_audio_ducking_enabled(false);
 ```


### PR DESCRIPTION
## Summary
- remove `new_with_ducking` and extend `new` with ducking flag
- keep a shared `AudioDucker` and tick flag for runtime control
- expose runtime APIs to toggle ducking and ticking
- update README usage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858cfaa0ae08332b28b55cd93a6bace