### PR TITLE
Update async-openai voices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,15 +84,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-convert"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,11 +144,11 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.25.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b17e44510f88a904cb3102a020d7ea11929dcddadfaff756e71112cb2cb7bd0"
+checksum = "4df839a6643e1e3248733b01f229dc4f462d7256f808bbaf04cac40739b345c2"
 dependencies = [
- "async-convert",
+ "async-openai-macros",
  "backoff",
  "base64",
  "bytes",
@@ -170,11 +161,22 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0289cba6d5143bfe8251d57b4a8cac036adf158525a76533a7082ba65ec76398"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -208,17 +210,6 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "atomic-waker"
@@ -1906,9 +1897,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
-async-openai = "0.25.0"
+async-openai = "0.28.3"
 async-std = "1.12.0"
 colored = "2.0"
 flume = "0.11"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A streaming text-to-speech library built on OpenAI's API. Feed tokens as they ar
 
 - 🎧 **Sentence-aware streaming** turns tokens into speech as soon as sentences are complete.
 - 🦢 **Optional audio ducking** lowers other application volumes while speech plays and can be toggled at runtime.
-- 🗣️ **Change voices** easily using OpenAI's voice models.
+- 🗣️ **Change voices** easily using OpenAI's voice models (Alloy, Echo, Fable, Onyx, Nova, Shimmer, and new voices Ash, Coral, Sage).
 - ⏩ **Adjust playback speed** on the fly.
 - 🔇 **Mute/unmute** or stop speech instantly.
 - 🔊 **Automatic output device switching** via the `default-device-sink` crate.
@@ -44,7 +44,7 @@ use async_openai::types::Voice;
 
 #[tokio::main]
 async fn main() {
-    let mut speak = SpeakStream::new(Voice::Alloy, 1.0, true, false);
+    let mut speak = SpeakStream::new(Voice::Ash, 1.0, true, false);
     speak.add_token("Hello, world!");
     speak.complete_sentence();
 }
@@ -55,7 +55,7 @@ async fn main() {
 Audio ducking can be enabled when creating a new stream or toggled at runtime:
 
 ```rust
-let mut speak = SpeakStream::new(Voice::Alloy, 1.0, true, true);
+let mut speak = SpeakStream::new(Voice::Ash, 1.0, true, true);
 assert!(speak.is_audio_ducking_enabled());
 speak.set_audio_ducking_enabled(false);
 ```


### PR DESCRIPTION
## Summary
- upgrade async-openai to 0.28.3
- document new Ash/Coral/Sage voices in README
- use Voice::Ash in README example

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68590b323a408332a90e00998e85eb0e