### PR TITLE
Fix COM initialization during volume restore

### DIFF
--- a/src/audio_ducking.rs
+++ b/src/audio_ducking.rs
@@ -194,8 +194,14 @@ impl AudioDucker {
         if let Some(storage) = self.saved.get() {
             let mut saved = storage.lock().unwrap();
             unsafe {
-                for VolumePair(vol, val) in saved.iter() {
-                    let _ = vol.SetMasterVolume(*val, std::ptr::null());
+                let init = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+                if init.is_ok() {
+                    for VolumePair(vol, val) in saved.iter() {
+                        let _ = vol.SetMasterVolume(*val, std::ptr::null());
+                    }
+                    if init == S_OK {
+                        CoUninitialize();
+                    }
                 }
             }
             saved.clear();


### PR DESCRIPTION
## Summary
- initialize COM before restoring volumes on Windows

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685f903b32c0833292e16229f413b795