### PR TITLE
Add manual audio ducking control

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Audio ducking can be enabled when creating a new stream or toggled at runtime:
 let mut speak = SpeakStream::new(Voice::Ash, 1.0, true, true);
 assert!(speak.is_audio_ducking_enabled());
 speak.set_audio_ducking_enabled(false);
+// manually start ducking when the user begins talking
+speak.start_audio_ducking();
+// ...record microphone input...
+speak.stop_audio_ducking();
 ```
 
 ## License

--- a/src/ss.rs
+++ b/src/ss.rs
@@ -675,6 +675,21 @@ impl SpeakStream {
         self.audio_ducker.is_enabled()
     }
 
+    /// Manually start audio ducking regardless of whether the stream is
+    /// currently speaking. This can be useful to integrate with push-to-talk
+    /// systems so that other application volumes are lowered when the user
+    /// begins talking.
+    pub fn start_audio_ducking(&self) {
+        self.audio_ducker.duck();
+    }
+
+    /// Manually restore audio levels after a call to `start_audio_ducking`.
+    /// If speech is currently playing, levels will be restored automatically
+    /// when it finishes, so this is primarily for external integrations.
+    pub fn stop_audio_ducking(&self) {
+        self.audio_ducker.restore();
+    }
+
     pub fn set_tick_enabled(&self, enabled: bool) {
         self.tick_enabled.store(enabled, Ordering::SeqCst);
     }
@@ -717,5 +732,12 @@ mod tests {
 
         acc.add_token("This is the last");
         assert!(acc.complete_sentence().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_manual_ducking_no_panic() {
+        let speak = SpeakStream::new(Voice::Echo, 1.0, false, false);
+        speak.start_audio_ducking();
+        speak.stop_audio_ducking();
     }
 }


### PR DESCRIPTION
## Summary
- expose public functions on `SpeakStream` to manually start/stop audio ducking
- document manual ducking in README
- test manual ducking

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860bf7058308332b9a5891a0a99a240